### PR TITLE
Add simple response caching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -75,6 +75,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
 name = "byteorder"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -91,6 +100,35 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "cpufeatures"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "crypto-common"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "errno"
@@ -113,6 +151,16 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
 
 [[package]]
 name = "getrandom"
@@ -229,6 +277,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "o-dns-lib",
+ "sha1",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -451,6 +500,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "sharded-slab"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -618,6 +678,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
+
+[[package]]
 name = "unarray"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -634,6 +700,12 @@ name = "valuable"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "wait-timeout"

--- a/crates/o-dns-lib/src/lib.rs
+++ b/crates/o-dns-lib/src/lib.rs
@@ -429,7 +429,7 @@ mod tests {
             .push(Question::new("test.com", QueryType::A));
         // Add answers
         dns_packet.answers.push(ResourceRecord::new(
-            "test.com",
+            "test.com".into(),
             ResourceData::A {
                 address: Ipv4Addr::LOCALHOST,
             },
@@ -468,7 +468,7 @@ mod tests {
             .push(Question::new("test.com", QueryType::A));
         // Add answers
         dns_packet.answers.push(ResourceRecord::new(
-            "test.com",
+            "test.com".into(),
             ResourceData::A {
                 address: Ipv4Addr::LOCALHOST,
             },
@@ -512,7 +512,7 @@ mod tests {
             .push(Question::new("test.com", QueryType::A));
         // Add answers
         dns_packet.answers.push(ResourceRecord::new(
-            "test.com",
+            "test.com".into(),
             ResourceData::A {
                 address: Ipv4Addr::LOCALHOST,
             },
@@ -558,7 +558,7 @@ mod tests {
             .push(Question::new("test.com", QueryType::A));
         // Add answers
         dns_packet.answers.push(ResourceRecord::new(
-            "test.com",
+            "test.com".into(),
             ResourceData::A {
                 address: Ipv4Addr::LOCALHOST,
             },
@@ -566,7 +566,7 @@ mod tests {
             None,
         ));
         dns_packet.answers.push(ResourceRecord::new(
-            "test.com",
+            "test.com".into(),
             ResourceData::AAAA {
                 address: Ipv6Addr::LOCALHOST,
             },
@@ -600,7 +600,7 @@ mod tests {
         dns_packet.header.additional_rr_count = 1;
         // Add OPT RR
         dns_packet.additionals.push(ResourceRecord::new(
-            "",
+            "test.com".into(),
             ResourceData::OPT { options: None },
             Some(1232),
             None,
@@ -624,7 +624,7 @@ mod tests {
             .push(Question::new("test.com", QueryType::A));
         // Add OPT RR
         dns_packet.additionals.push(ResourceRecord::new(
-            "",
+            "test.com".into(),
             ResourceData::OPT { options: None },
             Some(1232),
             None,

--- a/crates/o-dns-lib/src/resource_record.rs
+++ b/crates/o-dns-lib/src/resource_record.rs
@@ -22,13 +22,13 @@ pub struct ResourceRecord<'a> {
 
 impl<'a> ResourceRecord<'a> {
     pub fn new<'s: 'a>(
-        name: &'s str,
+        name: Cow<'s, str>,
         resource_data: ResourceData<'a>,
         ttl: Option<u32>,
         class: Option<u16>,
     ) -> Self {
         ResourceRecord {
-            name: name.into(),
+            name,
             ttl: ttl.unwrap_or_default(),
             class: class.unwrap_or(1),
             resource_data,

--- a/crates/o-dns/Cargo.toml
+++ b/crates/o-dns/Cargo.toml
@@ -16,3 +16,4 @@ tokio = { version = "1.40.0", features = [
     "sync",
     "io-util",
 ] }
+sha1 = "0.10.6"

--- a/crates/o-dns/src/cache.rs
+++ b/crates/o-dns/src/cache.rs
@@ -1,0 +1,65 @@
+use std::{collections::HashMap, time::Instant};
+
+use o_dns_lib::{ResourceData, ResourceRecord};
+
+pub enum Kind {
+    Answer,
+    Authority,
+    Additional,
+}
+
+pub enum Source {
+    Local,
+    Upstream,
+}
+
+pub struct CacheEntry {
+    resource_data: ResourceData<'static>,
+    ttl: u32,
+    added: Instant,
+    kind: Kind,
+    source: Source,
+}
+
+impl CacheEntry {
+    pub fn new(value: ResourceRecord<'static>, kind: Kind, source: Source) -> Self {
+        CacheEntry {
+            resource_data: value.resource_data,
+            ttl: value.ttl,
+            added: Instant::now(),
+            kind,
+            source,
+        }
+    }
+
+    pub fn into_rr_with_qname<'s>(&self, qname: &'s str) -> ResourceRecord<'s> {
+        let ttl = self
+            .ttl
+            .saturating_sub(self.added.elapsed().as_secs() as u32);
+        ResourceRecord::new(qname, self.resource_data.clone(), Some(ttl), None)
+    }
+}
+
+#[derive(Default)]
+pub struct Cache {
+    internal: HashMap<String, Vec<CacheEntry>>,
+}
+
+impl Cache {
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    pub fn set(&mut self, key: String, value: ResourceRecord<'static>, kind: Kind, source: Source) {
+        let cache = self.internal.entry(key).or_default();
+        cache.push(CacheEntry::new(value, kind, source));
+    }
+
+    pub fn get(&self, key: &str) -> Option<&[CacheEntry]> {
+        self.internal.get(key).map(|cached| cached.as_slice())
+    }
+
+    pub fn contains(&self, key: &str) -> bool {
+        self.internal.contains_key(key)
+    }
+}

--- a/crates/o-dns/src/lib.rs
+++ b/crates/o-dns/src/lib.rs
@@ -1,10 +1,12 @@
 mod logging;
+use cache::Cache;
 pub use logging::setup_logging;
 mod hosts;
 pub use hosts::{Blacklist, Hosts};
 mod upstream;
 pub use upstream::resolve_with_upstream;
 mod cache;
+pub use cache::{CacheRecordKind, CachedRecord};
 pub mod util;
 
 use std::net::SocketAddr;
@@ -19,6 +21,7 @@ pub struct State {
     pub upstream_resolver: SocketAddr,
     pub blacklist: RwLock<Blacklist>,
     pub hosts: RwLock<Hosts>,
+    pub cache: RwLock<Cache>,
 }
 
 impl State {
@@ -27,6 +30,7 @@ impl State {
             upstream_resolver: "1.1.1.1:53".parse().expect("shouldn't have failed"),
             blacklist: Default::default(),
             hosts: Default::default(),
+            cache: Default::default(),
         }
     }
 }

--- a/crates/o-dns/src/lib.rs
+++ b/crates/o-dns/src/lib.rs
@@ -4,6 +4,7 @@ mod hosts;
 pub use hosts::{Blacklist, Hosts};
 mod upstream;
 pub use upstream::resolve_with_upstream;
+mod cache;
 pub mod util;
 
 use std::net::SocketAddr;

--- a/crates/o-dns/src/main.rs
+++ b/crates/o-dns/src/main.rs
@@ -1,8 +1,8 @@
 use anyhow::Context as _;
-use o_dns::util::{get_edns_rr, get_empty_dns_packet};
+use o_dns::util::{get_dns_query_hash, get_edns_rr, get_empty_dns_packet};
 use o_dns::{
-    resolve_with_upstream, setup_logging, State, DEFAULT_EDNS_BUF_CAPACITY,
-    MAX_STANDARD_DNS_MSG_SIZE,
+    resolve_with_upstream, setup_logging, CacheRecordKind, CachedRecord, State,
+    DEFAULT_EDNS_BUF_CAPACITY, MAX_STANDARD_DNS_MSG_SIZE,
 };
 use o_dns_lib::{ByteBuf, DnsPacket, QueryType, ResourceData, ResourceRecord, ResponseCode};
 use o_dns_lib::{EncodeToBuf as _, FromBuf as _};
@@ -158,80 +158,159 @@ async fn handle_query(
         edns_buf_length,
     );
 
+    let mut hash: Option<u128> = None;
+    let mut used_cache = false;
     if let Ok(packet) = parsed_packet.as_ref() {
         if packet.header.question_count == 1 && packet.questions.len() == 1 {
             let question = &packet.questions[0];
-            // Check if requested host is explicitly blacklisted
-            if state.blacklist.read().await.contains_entry(&question.qname) {
-                response_packet.header.is_authoritative = true;
-                let rdata: Option<ResourceData<'_>> = match question.query_type {
-                    // Send only A records to ANY queries if blacklisted
-                    QueryType::A | QueryType::ANY => Some(ResourceData::A {
-                        address: Ipv4Addr::UNSPECIFIED,
-                    }),
-                    QueryType::AAAA => Some(ResourceData::AAAA {
-                        address: Ipv6Addr::UNSPECIFIED,
-                    }),
-                    // Return an empty response for all other query types
-                    _ => None,
-                };
-                if let Some(rdata) = rdata {
-                    let rr = ResourceRecord::new(&question.qname, rdata, Some(180), None);
-                    response_packet.answers.push(rr);
-                    response_packet.header.answer_rr_count += 1;
-                }
-            }
-            if let Some(records) = state.hosts.read().await.get_entry(&question.qname) {
-                response_packet.header.is_authoritative = true;
-                records
-                    .iter()
-                    .filter(|rdata| match question.query_type {
-                        QueryType::ANY => true,
-                        qtype => rdata.get_query_type() == qtype,
-                    })
-                    .for_each(|rdata| {
-                        let rr =
-                            ResourceRecord::new(&question.qname, rdata.clone(), Some(180), None);
-                        response_packet.answers.push(rr);
-                        response_packet.header.answer_rr_count += 1;
-                    });
-            } else {
-                // TODO: can cloning be avoided?
-                match resolve_with_upstream(packet.clone(), state.upstream_resolver).await {
-                    Ok((mut upstream_response, _)) => {
-                        match upstream_response.edns {
-                            Some(idx) => {
-                                // The requestor doesn't support EDNS
-                                if edns_buf_length.is_none() {
-                                    // Remove the OPT RR
-                                    upstream_response.additionals.remove(idx);
-                                    upstream_response.header.additional_rr_count -= 1;
-                                } else {
-                                    if let Some(edns_record) =
-                                        upstream_response.additionals.get_mut(idx)
-                                    {
-                                        // Set the EDNS buffer size to the correct one for this resolver
-                                        edns_record.class = DEFAULT_EDNS_BUF_CAPACITY as u16
-                                    }
-                                }
+
+            // Calculate hash of the query for caching and cache lookup
+            hash = Some(get_dns_query_hash(
+                &packet.header,
+                question,
+                packet.edns.and_then(|idx| packet.additionals.get(idx)),
+            ));
+
+            if let Some(cached_response) = state.cache.read().await.get(hash.as_ref().unwrap()) {
+                // Response for this query is cached. Check if cache isn't stale
+                if (cached_response.added.elapsed().as_secs() as u32) < cached_response.ttd {
+                    tracing::debug!(
+                        qname = ?question.qname,
+                        qtype = ?question.query_type,
+                        remaining_time = (cached_response.ttd.saturating_sub(cached_response.added.elapsed().as_secs() as u32)),
+                        "Cache hit"
+                    );
+
+                    // Cache entry is not stale, use it as a response
+                    cached_response.records.iter().for_each(|cached_record| {
+                        // Override OPT RR if it's present
+                        if cached_record.resource_data.get_query_type() == QueryType::OPT {
+                            if response_packet.edns.is_some() {
+                                response_packet
+                                    .edns
+                                    .and_then(|idx| response_packet.additionals.get_mut(idx))
+                                    .into_iter()
+                                    .for_each(|opt_rr| {
+                                        // Override the stub OPT RR that was set when creating an empty response packet
+                                        *opt_rr = cached_record.into_rr(&cached_response.added);
+                                    });
                             }
-                            None => {
-                                // Add an OPT RR only if requestor supports EDNS
-                                if let Some(buf_length) = edns_buf_length {
-                                    let edns_idx = upstream_response.additionals.len();
-                                    let edns_record = get_edns_rr(buf_length as u16, None);
-                                    upstream_response.additionals.push(edns_record);
-                                    upstream_response.header.additional_rr_count += 1;
-                                    upstream_response.edns = Some(edns_idx);
-                                }
+                            return;
+                        }
+
+                        let rr = cached_record.into_rr(&cached_response.added);
+                        match cached_record.kind {
+                            CacheRecordKind::Answer => {
+                                response_packet.answers.push(rr);
+                                response_packet.header.answer_rr_count += 1;
+                            }
+                            CacheRecordKind::Authority => {
+                                response_packet.authorities.push(rr);
+                                response_packet.header.authority_rr_count += 1;
+                            }
+                            CacheRecordKind::Additional => {
+                                response_packet.additionals.push(rr);
+                                response_packet.header.additional_rr_count += 1;
                             }
                         }
-                        // Forward the upstream response to the requestor
-                        response_packet = upstream_response;
+                    });
+                    used_cache = true;
+                } else {
+                    tracing::debug!(
+                        qname = ?question.qname,
+                        qtype = ?question.query_type,
+                        "Found entry in cache, but it's stale. Doing a lookup"
+                    );
+                }
+            } else {
+                tracing::debug!(
+                    qname = ?question.qname,
+                    qtype = ?question.query_type,
+                    "Cache miss"
+                );
+            }
+
+            if !used_cache {
+                // Check if requested host is explicitly blacklisted
+                if state.blacklist.read().await.contains_entry(&question.qname) {
+                    response_packet.header.is_authoritative = true;
+                    let rdata: Option<ResourceData<'_>> = match question.query_type {
+                        // Send only A records to ANY queries if blacklisted
+                        QueryType::A | QueryType::ANY => Some(ResourceData::A {
+                            address: Ipv4Addr::UNSPECIFIED,
+                        }),
+                        QueryType::AAAA => Some(ResourceData::AAAA {
+                            address: Ipv6Addr::UNSPECIFIED,
+                        }),
+                        // Return an empty response for all other query types
+                        _ => None,
+                    };
+                    if let Some(rdata) = rdata {
+                        let rr =
+                            ResourceRecord::new(question.qname.clone(), rdata, Some(180), None);
+                        response_packet.answers.push(rr);
+                        response_packet.header.answer_rr_count += 1;
                     }
-                    Err(e) => {
-                        response_packet.header.response_code = ResponseCode::ServerFailure;
-                        tracing::debug!(resolver = ?state.upstream_resolver, "Error while forwarding a request to the upstream resolver: {}", e);
+                } else {
+                    if let Some(records) = state.hosts.read().await.get_entry(&question.qname) {
+                        response_packet.header.is_authoritative = true;
+                        records
+                            .iter()
+                            .filter(|rdata| match question.query_type {
+                                QueryType::ANY => true,
+                                qtype => rdata.get_query_type() == qtype,
+                            })
+                            .for_each(|rdata| {
+                                let rr = ResourceRecord::new(
+                                    question.qname.clone(),
+                                    rdata.clone(),
+                                    Some(180),
+                                    None,
+                                );
+                                response_packet.answers.push(rr);
+                                response_packet.header.answer_rr_count += 1;
+                            });
+                    } else {
+                        // TODO: can cloning be avoided?
+                        match resolve_with_upstream(packet.clone(), state.upstream_resolver).await {
+                            Ok((mut upstream_response, _)) => {
+                                match upstream_response.edns {
+                                    Some(idx) => {
+                                        // The requestor doesn't support EDNS
+                                        if edns_buf_length.is_none() {
+                                            // Remove the OPT RR
+                                            upstream_response.additionals.remove(idx);
+                                            upstream_response.header.additional_rr_count -= 1;
+                                        } else {
+                                            if let Some(edns_record) =
+                                                upstream_response.additionals.get_mut(idx)
+                                            {
+                                                // Set the EDNS buffer size to the correct one for this resolver
+                                                edns_record.class = DEFAULT_EDNS_BUF_CAPACITY as u16
+                                            }
+                                        }
+                                    }
+                                    None => {
+                                        // Add an OPT RR only if requestor supports EDNS
+                                        if let Some(buf_length) = edns_buf_length {
+                                            let edns_idx = upstream_response.additionals.len();
+                                            let edns_record = get_edns_rr(buf_length as u16, None);
+                                            upstream_response.additionals.push(edns_record);
+                                            upstream_response.header.additional_rr_count += 1;
+                                            upstream_response.edns = Some(edns_idx);
+                                        }
+                                    }
+                                }
+                                // Forward the upstream response to the requestor
+                                response_packet = upstream_response;
+                                // This response is not authoritative
+                                response_packet.header.is_authoritative = false;
+                            }
+                            Err(e) => {
+                                response_packet.header.response_code = ResponseCode::ServerFailure;
+                                tracing::debug!(resolver = ?state.upstream_resolver, "Error while forwarding a request to the upstream resolver: {}", e);
+                            }
+                        }
                     }
                 }
             }
@@ -259,6 +338,70 @@ async fn handle_query(
             (!is_using_tcp).then(|| edns_buf_length.unwrap_or(MAX_STANDARD_DNS_MSG_SIZE)),
         )
         .context("error while encoding the response")?;
+
+    // Cache only if response isn't from the cache
+    if !used_cache {
+        // We can't cache anything if we didn't manage to calculate the hash
+        if let Some(hash) = hash {
+            let cache_for = match response_packet.header.response_code {
+                // Cache for the lowest TTL from all response RRs
+                ResponseCode::Success => {
+                    // Cache for 5 mins by default
+                    // TODO: fix this, as some responses can be cached for longer
+                    let mut lowest_ttl = 60 * 5;
+                    response_packet
+                        .answers
+                        .iter()
+                        .chain(response_packet.authorities.iter())
+                        .chain(response_packet.additionals.iter())
+                        .for_each(|rr| {
+                            if rr.resource_data.get_query_type() != QueryType::OPT {
+                                lowest_ttl = lowest_ttl.min(rr.ttl);
+                            }
+                        });
+                    lowest_ttl
+                }
+                // Cache for 1 min
+                // TODO: cache NXDOMAIN for SOA TTL (or 1 min if SOA is missing)
+                ResponseCode::Refused | ResponseCode::NameError => 60,
+                // Cache for 30s
+                ResponseCode::ServerFailure => 30,
+                // Cache for 5 min
+                ResponseCode::NotImplemented => 60 * 5,
+                // Don't cache these responses
+                ResponseCode::FormatError | ResponseCode::Unknown => 0,
+            };
+
+            let mut cache = state.cache.write().await;
+            // No point in caching packets with TTL lower than 15s IMO
+            if cache_for >= 15 {
+                // Set an empty cache record in case there are no records in the response
+                cache.set_empty(hash, cache_for);
+
+                response_packet.answers.iter().for_each(|rr| {
+                    cache.set(
+                        hash,
+                        CachedRecord::new(rr.clone(), CacheRecordKind::Answer),
+                        cache_for,
+                    )
+                });
+                response_packet.authorities.iter().for_each(|rr| {
+                    cache.set(
+                        hash,
+                        CachedRecord::new(rr.clone(), CacheRecordKind::Authority),
+                        cache_for,
+                    )
+                });
+                response_packet.additionals.iter().for_each(|rr| {
+                    cache.set(
+                        hash,
+                        CachedRecord::new(rr.clone(), CacheRecordKind::Additional),
+                        cache_for,
+                    )
+                });
+            }
+        }
+    }
 
     Ok(dst.into_inner().into_owned())
 }

--- a/crates/o-dns/src/util.rs
+++ b/crates/o-dns/src/util.rs
@@ -1,6 +1,7 @@
 use std::{borrow::Cow, collections::HashMap};
 
-use o_dns_lib::{DnsHeader, DnsPacket, ResourceData, ResourceRecord, ResponseCode};
+use o_dns_lib::{DnsHeader, DnsPacket, Question, ResourceData, ResourceRecord, ResponseCode};
+use sha1::Digest;
 
 pub fn get_empty_dns_packet(
     response_code: Option<ResponseCode>,
@@ -26,5 +27,42 @@ pub fn get_empty_dns_packet(
 }
 
 pub fn get_edns_rr(buf_size: u16, options: Option<HashMap<u16, Cow<'_, [u8]>>>) -> ResourceRecord {
-    ResourceRecord::new("", ResourceData::OPT { options }, Some(0), Some(buf_size))
+    ResourceRecord::new(
+        "".into(),
+        ResourceData::OPT { options },
+        Some(0),
+        Some(buf_size),
+    )
+}
+
+pub fn get_dns_query_hash(
+    header: &DnsHeader,
+    question: &Question,
+    opt_rr: Option<&ResourceRecord>,
+) -> u128 {
+    let mut hasher = sha1::Sha1::new();
+
+    // Hash the RD bit as it changes how a query is processed
+    hasher.update(&[header.recursion_desired as u8]);
+    // Hash the Z->CD bit as it changes how DNSSEC queries are processed
+    hasher.update(&[header.z[1] as u8]);
+
+    // Hash the question itself
+    hasher.update(question.qname.as_bytes());
+    hasher.update(Into::<u16>::into(question.query_type).to_be_bytes());
+
+    // Hash EDNS-related data
+    if let Some((edns_data, _)) = opt_rr.and_then(|rr| {
+        rr.get_edns_data()
+            .map(|edns_data| (edns_data, &rr.resource_data))
+    }) {
+        hasher.update(&[edns_data.dnssec_ok_bit as u8]);
+        // TODO: also hash certain options, as they may change the response?
+    }
+
+    let hash = hasher.finalize();
+    // Reduce the output hash to first 16 bytes in order to fit it into a single u128
+    // NOTE: it increases chances of hash collissions, but it shouldn't affect this server in any meaningful way
+    // It's still worth looking into fixing this at some point in the future though
+    u128::from_be_bytes(hash[..16].try_into().unwrap())
 }


### PR DESCRIPTION
This adds simple response caching based on question/flags.
This approach leads to unnecessary duplicates in the cache and may also contain some bug that I haven't found yet.

A proper caching solution requires more time, so this is good enough for now (at least until I have more time to work on it)